### PR TITLE
#1 Switches to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,1230 +1,1084 @@
 {
-    "name": "texturepacker",
-    "version": "0.0.1",
+    "name": "texturepacker-command-line",
+    "version": "0.0.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.0.0-beta.46",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz",
-            "integrity": "sha512-7BKRkmYaPZm3Yff5HGZJKCz7RqZ5jUjknsXT6Gz5YKG23J3uq9hAj0epncCB0rlqmnZ8Q+UUpQB2tCR5mT37vw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+            "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+            "dev": true,
             "requires": {
-                "@babel/highlight": "7.0.0-beta.46"
+                "@babel/highlight": "^7.8.3"
             }
         },
+        "@babel/helper-validator-identifier": {
+            "version": "7.9.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+            "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+            "dev": true
+        },
         "@babel/highlight": {
-            "version": "7.0.0-beta.46",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.46.tgz",
-            "integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+            "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+            "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "@babel/helper-validator-identifier": "^7.9.0",
+                "chalk": "^2.0.0",
+                "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "abab": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-            "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
+            "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
+            "dev": true
         },
         "acorn": {
-            "version": "5.5.3",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-            "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
+            "version": "5.7.4",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+            "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+            "dev": true
         },
         "acorn-globals": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
-            "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+            "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+            "dev": true,
             "requires": {
-                "acorn": "5.5.3"
+                "acorn": "^6.0.1",
+                "acorn-walk": "^6.0.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+                    "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+                    "dev": true
+                }
             }
+        },
+        "acorn-walk": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+            "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
+            "dev": true
         },
         "ajv": {
-            "version": "5.5.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "version": "6.12.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+            "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+            "dev": true,
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
             }
-        },
-        "align-text": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-            "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
-            }
-        },
-        "amdefine": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
         },
         "ansi-escapes": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-            "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+            "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+            "dev": true
         },
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
         },
         "ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "requires": {
-                "color-convert": "1.9.1"
-            }
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
         },
         "anymatch": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-            "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+            "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+            "dev": true,
+            "optional": true,
             "requires": {
-                "micromatch": "3.1.10",
-                "normalize-path": "2.1.1"
-            },
-            "dependencies": {
-                "arr-diff": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-                },
-                "array-unique": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-                },
-                "braces": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-                    "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "0.1.1"
-                            }
-                        }
-                    }
-                },
-                "expand-brackets": {
-                    "version": "2.1.4",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-                    "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "0.2.5",
-                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                            "requires": {
-                                "is-descriptor": "0.1.6"
-                            }
-                        },
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "0.1.1"
-                            }
-                        },
-                        "is-accessor-descriptor": {
-                            "version": "0.1.6",
-                            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-                            "requires": {
-                                "kind-of": "3.2.2"
-                            },
-                            "dependencies": {
-                                "kind-of": {
-                                    "version": "3.2.2",
-                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                                    "requires": {
-                                        "is-buffer": "1.1.6"
-                                    }
-                                }
-                            }
-                        },
-                        "is-data-descriptor": {
-                            "version": "0.1.4",
-                            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                            "requires": {
-                                "kind-of": "3.2.2"
-                            },
-                            "dependencies": {
-                                "kind-of": {
-                                    "version": "3.2.2",
-                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                                    "requires": {
-                                        "is-buffer": "1.1.6"
-                                    }
-                                }
-                            }
-                        },
-                        "is-descriptor": {
-                            "version": "0.1.6",
-                            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                            "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
-                            }
-                        },
-                        "kind-of": {
-                            "version": "5.1.0",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-                        }
-                    }
-                },
-                "extglob": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-                    "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-                    "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                            "requires": {
-                                "is-descriptor": "1.0.2"
-                            }
-                        },
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "0.1.1"
-                            }
-                        }
-                    }
-                },
-                "fill-range": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-                    "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "0.1.1"
-                            }
-                        }
-                    }
-                },
-                "is-accessor-descriptor": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "requires": {
-                        "kind-of": "6.0.2"
-                    }
-                },
-                "is-data-descriptor": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "requires": {
-                        "kind-of": "6.0.2"
-                    }
-                },
-                "is-descriptor": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
-                    }
-                },
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "requires": {
-                        "kind-of": "3.2.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "requires": {
-                                "is-buffer": "1.1.6"
-                            }
-                        }
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-                },
-                "kind-of": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-                },
-                "micromatch": {
-                    "version": "3.1.10",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-                    "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.9",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
-                    }
-                }
+                "micromatch": "^2.1.5",
+                "normalize-path": "^2.0.0"
             }
         },
         "append-transform": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
             "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+            "dev": true,
             "requires": {
-                "default-require-extensions": "1.0.0"
+                "default-require-extensions": "^1.0.0"
             }
         },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "arr-diff": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+            "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0"
+                "arr-flatten": "^1.0.1"
             }
         },
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "dev": true
         },
         "arr-union": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+            "dev": true
         },
         "array-equal": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-            "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+            "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+            "dev": true
         },
         "array-unique": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+            "dev": true
         },
         "arrify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "dev": true
         },
         "asn1": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
         },
         "assert-plus": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
         },
         "assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+            "dev": true
         },
         "astral-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-            "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+            "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+            "dev": true
         },
         "async": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-            "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+            "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+            "dev": true,
             "requires": {
-                "lodash": "4.17.10"
+                "lodash": "^4.17.14"
             }
         },
         "async-each": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-            "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+            "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+            "dev": true,
             "optional": true
         },
         "async-limiter": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-            "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+            "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+            "dev": true
         },
         "asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
         },
         "atob": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-            "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+            "dev": true
         },
         "aws-sign2": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true
         },
         "aws4": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-            "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+            "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+            "dev": true
         },
         "babel-cli": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
             "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+            "dev": true,
             "requires": {
-                "babel-core": "6.26.3",
-                "babel-polyfill": "6.26.0",
-                "babel-register": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "chokidar": "1.7.0",
-                "commander": "2.15.1",
-                "convert-source-map": "1.5.1",
-                "fs-readdir-recursive": "1.1.0",
-                "glob": "7.1.2",
-                "lodash": "4.17.10",
-                "output-file-sync": "1.1.2",
-                "path-is-absolute": "1.0.1",
-                "slash": "1.0.0",
-                "source-map": "0.5.7",
-                "v8flags": "2.1.1"
+                "babel-core": "^6.26.0",
+                "babel-polyfill": "^6.26.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "chokidar": "^1.6.1",
+                "commander": "^2.11.0",
+                "convert-source-map": "^1.5.0",
+                "fs-readdir-recursive": "^1.0.0",
+                "glob": "^7.1.2",
+                "lodash": "^4.17.4",
+                "output-file-sync": "^1.1.2",
+                "path-is-absolute": "^1.0.1",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.6",
+                "v8flags": "^2.1.1"
             }
         },
         "babel-code-frame": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+            "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-                }
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             }
         },
         "babel-core": {
             "version": "6.26.3",
             "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
             "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+            "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-generator": "6.26.1",
-                "babel-helpers": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-register": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "convert-source-map": "1.5.1",
-                "debug": "2.6.9",
-                "json5": "0.5.1",
-                "lodash": "4.17.10",
-                "minimatch": "3.0.4",
-                "path-is-absolute": "1.0.1",
-                "private": "0.1.8",
-                "slash": "1.0.0",
-                "source-map": "0.5.7"
+                "babel-code-frame": "^6.26.0",
+                "babel-generator": "^6.26.0",
+                "babel-helpers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "convert-source-map": "^1.5.1",
+                "debug": "^2.6.9",
+                "json5": "^0.5.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.4",
+                "path-is-absolute": "^1.0.1",
+                "private": "^0.1.8",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.7"
             }
         },
         "babel-generator": {
             "version": "6.26.1",
             "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
             "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+            "dev": true,
             "requires": {
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "detect-indent": "4.0.0",
-                "jsesc": "1.3.0",
-                "lodash": "4.17.10",
-                "source-map": "0.5.7",
-                "trim-right": "1.0.1"
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "detect-indent": "^4.0.0",
+                "jsesc": "^1.3.0",
+                "lodash": "^4.17.4",
+                "source-map": "^0.5.7",
+                "trim-right": "^1.0.1"
             }
         },
         "babel-helper-builder-binary-assignment-operator-visitor": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
             "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+            "dev": true,
             "requires": {
-                "babel-helper-explode-assignable-expression": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-explode-assignable-expression": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-call-delegate": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
             "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+            "dev": true,
             "requires": {
-                "babel-helper-hoist-variables": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-hoist-variables": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-define-map": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
             "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+            "dev": true,
             "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.10"
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
             }
         },
         "babel-helper-explode-assignable-expression": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
             "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-function-name": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
             "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+            "dev": true,
             "requires": {
-                "babel-helper-get-function-arity": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-get-function-arity": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-get-function-arity": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
             "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-hoist-variables": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
             "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-optimise-call-expression": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
             "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-regex": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
             "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.10"
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
             }
         },
         "babel-helper-remap-async-to-generator": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
             "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+            "dev": true,
             "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-replace-supers": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
             "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+            "dev": true,
             "requires": {
-                "babel-helper-optimise-call-expression": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-optimise-call-expression": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helpers": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
             "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-jest": {
-            "version": "22.4.3",
-            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.3.tgz",
-            "integrity": "sha512-BgSjmtl3mW3i+VeVHEr9d2zFSAT66G++pJcHQiUjd00pkW+voYXFctIm/indcqOWWXw5a1nUpR1XWszD9fJ1qg==",
+            "version": "22.4.4",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.4.tgz",
+            "integrity": "sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==",
+            "dev": true,
             "requires": {
-                "babel-plugin-istanbul": "4.1.6",
-                "babel-preset-jest": "22.4.3"
+                "babel-plugin-istanbul": "^4.1.5",
+                "babel-preset-jest": "^22.4.4"
             }
         },
         "babel-messages": {
             "version": "6.23.0",
             "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
             "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-check-es2015-constants": {
             "version": "6.22.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
             "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-istanbul": {
             "version": "4.1.6",
             "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
             "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
+            "dev": true,
             "requires": {
-                "babel-plugin-syntax-object-rest-spread": "6.13.0",
-                "find-up": "2.1.0",
-                "istanbul-lib-instrument": "1.10.1",
-                "test-exclude": "4.2.1"
+                "babel-plugin-syntax-object-rest-spread": "^6.13.0",
+                "find-up": "^2.1.0",
+                "istanbul-lib-instrument": "^1.10.1",
+                "test-exclude": "^4.2.1"
             }
         },
         "babel-plugin-jest-hoist": {
-            "version": "22.4.3",
-            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz",
-            "integrity": "sha512-zhvv4f6OTWy2bYevcJftwGCWXMFe7pqoz41IhMi4xna7xNsX5NygdagsrE0y6kkfuXq8UalwvPwKTyAxME2E/g=="
+            "version": "22.4.4",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz",
+            "integrity": "sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ==",
+            "dev": true
         },
         "babel-plugin-syntax-async-functions": {
             "version": "6.13.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-            "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+            "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+            "dev": true
         },
         "babel-plugin-syntax-exponentiation-operator": {
             "version": "6.13.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-            "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+            "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+            "dev": true
         },
         "babel-plugin-syntax-object-rest-spread": {
             "version": "6.13.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-            "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+            "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+            "dev": true
         },
         "babel-plugin-syntax-trailing-function-commas": {
             "version": "6.22.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-            "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+            "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+            "dev": true
         },
         "babel-plugin-transform-async-to-generator": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
             "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+            "dev": true,
             "requires": {
-                "babel-helper-remap-async-to-generator": "6.24.1",
-                "babel-plugin-syntax-async-functions": "6.13.0",
-                "babel-runtime": "6.26.0"
+                "babel-helper-remap-async-to-generator": "^6.24.1",
+                "babel-plugin-syntax-async-functions": "^6.8.0",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-arrow-functions": {
             "version": "6.22.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
             "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
             "version": "6.22.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
             "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-block-scoping": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
             "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.10"
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
             }
         },
         "babel-plugin-transform-es2015-classes": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
             "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+            "dev": true,
             "requires": {
-                "babel-helper-define-map": "6.26.0",
-                "babel-helper-function-name": "6.24.1",
-                "babel-helper-optimise-call-expression": "6.24.1",
-                "babel-helper-replace-supers": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-define-map": "^6.24.1",
+                "babel-helper-function-name": "^6.24.1",
+                "babel-helper-optimise-call-expression": "^6.24.1",
+                "babel-helper-replace-supers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-computed-properties": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
             "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-destructuring": {
             "version": "6.23.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
             "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-duplicate-keys": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
             "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-for-of": {
             "version": "6.23.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
             "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-function-name": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
             "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+            "dev": true,
             "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-literals": {
             "version": "6.22.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
             "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-modules-amd": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
             "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+            "dev": true,
             "requires": {
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
             "version": "6.26.2",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
             "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+            "dev": true,
             "requires": {
-                "babel-plugin-transform-strict-mode": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-plugin-transform-strict-mode": "^6.24.1",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-types": "^6.26.0"
             }
         },
         "babel-plugin-transform-es2015-modules-systemjs": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
             "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+            "dev": true,
             "requires": {
-                "babel-helper-hoist-variables": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-helper-hoist-variables": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-modules-umd": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
             "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+            "dev": true,
             "requires": {
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-object-super": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
             "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+            "dev": true,
             "requires": {
-                "babel-helper-replace-supers": "6.24.1",
-                "babel-runtime": "6.26.0"
+                "babel-helper-replace-supers": "^6.24.1",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-parameters": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
             "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+            "dev": true,
             "requires": {
-                "babel-helper-call-delegate": "6.24.1",
-                "babel-helper-get-function-arity": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-call-delegate": "^6.24.1",
+                "babel-helper-get-function-arity": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
             "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-spread": {
             "version": "6.22.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
             "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-sticky-regex": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
             "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+            "dev": true,
             "requires": {
-                "babel-helper-regex": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-regex": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-template-literals": {
             "version": "6.22.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
             "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-typeof-symbol": {
             "version": "6.23.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
             "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-unicode-regex": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
             "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+            "dev": true,
             "requires": {
-                "babel-helper-regex": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "regexpu-core": "2.0.0"
+                "babel-helper-regex": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "regexpu-core": "^2.0.0"
             }
         },
         "babel-plugin-transform-exponentiation-operator": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
             "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+            "dev": true,
             "requires": {
-                "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-                "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-                "babel-runtime": "6.26.0"
+                "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+                "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-regenerator": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
-            "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+            "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+            "dev": true,
             "requires": {
-                "regenerator-transform": "0.9.11"
+                "regenerator-transform": "^0.10.0"
             }
         },
         "babel-plugin-transform-strict-mode": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
             "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-polyfill": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
             "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "core-js": "2.5.6",
-                "regenerator-runtime": "0.10.5"
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "regenerator-runtime": "^0.10.5"
             },
             "dependencies": {
                 "regenerator-runtime": {
                     "version": "0.10.5",
                     "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-                    "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+                    "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+                    "dev": true
                 }
             }
         },
         "babel-preset-env": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-            "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+            "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+            "dev": true,
             "requires": {
-                "babel-plugin-check-es2015-constants": "6.22.0",
-                "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-                "babel-plugin-transform-async-to-generator": "6.24.1",
-                "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-                "babel-plugin-transform-es2015-classes": "6.24.1",
-                "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-                "babel-plugin-transform-es2015-destructuring": "6.23.0",
-                "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-                "babel-plugin-transform-es2015-for-of": "6.23.0",
-                "babel-plugin-transform-es2015-function-name": "6.24.1",
-                "babel-plugin-transform-es2015-literals": "6.22.0",
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-                "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-                "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-                "babel-plugin-transform-es2015-object-super": "6.24.1",
-                "babel-plugin-transform-es2015-parameters": "6.24.1",
-                "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-                "babel-plugin-transform-es2015-spread": "6.22.0",
-                "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-                "babel-plugin-transform-es2015-template-literals": "6.22.0",
-                "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-                "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-                "babel-plugin-transform-exponentiation-operator": "6.24.1",
-                "babel-plugin-transform-regenerator": "6.24.1",
-                "browserslist": "2.11.3",
-                "invariant": "2.2.4",
-                "semver": "5.5.0"
+                "babel-plugin-check-es2015-constants": "^6.22.0",
+                "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+                "babel-plugin-transform-async-to-generator": "^6.22.0",
+                "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+                "babel-plugin-transform-es2015-classes": "^6.23.0",
+                "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+                "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+                "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+                "babel-plugin-transform-es2015-for-of": "^6.23.0",
+                "babel-plugin-transform-es2015-function-name": "^6.22.0",
+                "babel-plugin-transform-es2015-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+                "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+                "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+                "babel-plugin-transform-es2015-object-super": "^6.22.0",
+                "babel-plugin-transform-es2015-parameters": "^6.23.0",
+                "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+                "babel-plugin-transform-es2015-spread": "^6.22.0",
+                "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+                "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+                "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+                "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+                "babel-plugin-transform-regenerator": "^6.22.0",
+                "browserslist": "^3.2.6",
+                "invariant": "^2.2.2",
+                "semver": "^5.3.0"
             }
         },
         "babel-preset-jest": {
-            "version": "22.4.3",
-            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz",
-            "integrity": "sha512-a+M3LTEXTq3gxv0uBN9Qm6ahUl7a8pj923nFbCUdqFUSsf3YrX8Uc+C3MEwji5Af3LiQjSC7w4ooYewlz8HRTA==",
+            "version": "22.4.4",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz",
+            "integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
+            "dev": true,
             "requires": {
-                "babel-plugin-jest-hoist": "22.4.3",
-                "babel-plugin-syntax-object-rest-spread": "6.13.0"
+                "babel-plugin-jest-hoist": "^22.4.4",
+                "babel-plugin-syntax-object-rest-spread": "^6.13.0"
             }
         },
         "babel-register": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
             "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+            "dev": true,
             "requires": {
-                "babel-core": "6.26.3",
-                "babel-runtime": "6.26.0",
-                "core-js": "2.5.6",
-                "home-or-tmp": "2.0.0",
-                "lodash": "4.17.10",
-                "mkdirp": "0.5.1",
-                "source-map-support": "0.4.18"
-            },
-            "dependencies": {
-                "source-map-support": {
-                    "version": "0.4.18",
-                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-                    "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-                    "requires": {
-                        "source-map": "0.5.7"
-                    }
-                }
+                "babel-core": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "home-or-tmp": "^2.0.0",
+                "lodash": "^4.17.4",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.4.15"
             }
         },
         "babel-runtime": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+            "dev": true,
             "requires": {
-                "core-js": "2.5.6",
-                "regenerator-runtime": "0.11.1"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
             }
         },
         "babel-template": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
             "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "lodash": "4.17.10"
+                "babel-runtime": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "lodash": "^4.17.4"
             }
         },
         "babel-traverse": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
             "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+            "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "debug": "2.6.9",
-                "globals": "9.18.0",
-                "invariant": "2.2.4",
-                "lodash": "4.17.10"
+                "babel-code-frame": "^6.26.0",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "debug": "^2.6.8",
+                "globals": "^9.18.0",
+                "invariant": "^2.2.2",
+                "lodash": "^4.17.4"
             }
         },
         "babel-types": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
             "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+            "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "esutils": "2.0.2",
-                "lodash": "4.17.10",
-                "to-fast-properties": "1.0.3"
+                "babel-runtime": "^6.26.0",
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.4",
+                "to-fast-properties": "^1.0.3"
             }
         },
         "babylon": {
             "version": "6.18.0",
             "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-            "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+            "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+            "dev": true
         },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
         },
         "base": {
             "version": "0.11.2",
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "dev": true,
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.2.1",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.1",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 },
                 "kind-of": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
                 }
             }
         },
         "bcrypt-pbkdf": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-            "optional": true,
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "dev": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "binary-extensions": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-            "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+            "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+            "dev": true,
             "optional": true
         },
-        "boom": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-            "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "dev": true,
+            "optional": true,
             "requires": {
-                "hoek": "4.2.1"
+                "file-uri-to-path": "1.0.0"
             }
         },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -1232,226 +1086,232 @@
             "version": "1.8.5",
             "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "dev": true,
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
             }
         },
         "browser-process-hrtime": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
-            "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+            "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+            "dev": true
         },
         "browser-resolve": {
-            "version": "1.11.2",
-            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-            "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+            "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+            "dev": true,
             "requires": {
                 "resolve": "1.1.7"
             }
         },
         "browserslist": {
-            "version": "2.11.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-            "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+            "version": "3.2.8",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+            "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+            "dev": true,
             "requires": {
-                "caniuse-lite": "1.0.30000836",
-                "electron-to-chromium": "1.3.45"
+                "caniuse-lite": "^1.0.30000844",
+                "electron-to-chromium": "^1.3.47"
             }
         },
         "bser": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
-            "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+            "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+            "dev": true,
             "requires": {
-                "node-int64": "0.4.0"
+                "node-int64": "^0.4.0"
             }
         },
         "buffer-from": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-            "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
-        },
-        "builtin-modules": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
         },
         "cache-base": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "dev": true,
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.2.1",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.0",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.0",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             },
             "dependencies": {
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 }
             }
         },
         "callsites": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-            "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+            "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+            "dev": true
         },
         "camelcase": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-            "optional": true
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+            "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+            "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30000836",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000836.tgz",
-            "integrity": "sha512-DlVR8sVTKDgd7t95U0shX3g7MeJ/DOjKOhUcaiXqnVmnO5sG4Tn2rLVOkVfPUJgnQNxnGe8/4GK0dGSI+AagQw=="
+            "version": "1.0.30001059",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001059.tgz",
+            "integrity": "sha512-oOrc+jPJWooKIA0IrNZ5sYlsXc7NP7KLhNWrSGEJhnfSzDvDJ0zd3i6HXsslExY9bbu+x0FQ5C61LcqmPt7bOQ==",
+            "dev": true
         },
         "capture-exit": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
             "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+            "dev": true,
             "requires": {
-                "rsvp": "3.6.2"
+                "rsvp": "^3.3.3"
             }
         },
         "caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-        },
-        "center-align": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-            "optional": true,
-            "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
-            }
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
         },
         "chalk": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-            "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.4.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
         "chokidar": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
             "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+            "dev": true,
             "optional": true,
             "requires": {
-                "anymatch": "1.3.2",
-                "async-each": "1.0.1",
-                "fsevents": "1.2.3",
-                "glob-parent": "2.0.0",
-                "inherits": "2.0.3",
-                "is-binary-path": "1.0.1",
-                "is-glob": "2.0.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0"
-            },
-            "dependencies": {
-                "anymatch": {
-                    "version": "1.3.2",
-                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-                    "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-                    "optional": true,
-                    "requires": {
-                        "micromatch": "2.3.11",
-                        "normalize-path": "2.1.1"
-                    }
-                }
+                "anymatch": "^1.3.0",
+                "async-each": "^1.0.0",
+                "fsevents": "^1.0.0",
+                "glob-parent": "^2.0.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^2.0.0",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0"
             }
         },
         "ci-info": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-            "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg=="
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+            "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+            "dev": true
         },
         "class-utils": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+            "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 }
             }
         },
         "cliui": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-            "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-            "optional": true,
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+            "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+            "dev": true,
             "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
-                "wordwrap": "0.0.2"
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
             },
             "dependencies": {
-                "wordwrap": {
-                    "version": "0.0.2",
-                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                    "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-                    "optional": true
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
                 }
             }
         },
         "co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
         },
         "code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
         },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "dev": true,
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color-convert": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
             "requires": {
                 "color-name": "1.1.3"
             }
@@ -1459,119 +1319,127 @@
         "color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
         },
         "combined-stream": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-            "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
-        },
-        "compare-versions": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.1.0.tgz",
-            "integrity": "sha512-4hAxDSBypT/yp2ySFD346So6Ragw5xmBn/e/agIGl3bZr6DLUqnoRZPusxKrXdYRZpgexO9daejmIenlq/wrIQ=="
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
         },
         "component-emitter": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+            "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+            "dev": true
         },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "convert-source-map": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+            "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
         },
         "copy-descriptor": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+            "dev": true
         },
         "core-js": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
-            "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ=="
+            "version": "2.6.11",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+            "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+            "dev": true
         },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
         },
         "cross-spawn": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+            "dev": true,
             "requires": {
-                "lru-cache": "4.1.3",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
-            }
-        },
-        "cryptiles": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-            "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-            "requires": {
-                "boom": "5.2.0"
-            },
-            "dependencies": {
-                "boom": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-                    "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-                    "requires": {
-                        "hoek": "4.2.1"
-                    }
-                }
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             }
         },
         "cssom": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-            "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+            "version": "0.3.8",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+            "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+            "dev": true
         },
         "cssstyle": {
-            "version": "0.2.37",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-            "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+            "integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
+            "dev": true,
             "requires": {
-                "cssom": "0.3.2"
+                "cssom": "0.3.x"
             }
         },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "data-urls": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
-            "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+            "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+            "dev": true,
             "requires": {
-                "abab": "1.0.4",
-                "whatwg-mimetype": "2.1.0",
-                "whatwg-url": "6.4.1"
+                "abab": "^2.0.0",
+                "whatwg-mimetype": "^2.2.0",
+                "whatwg-url": "^7.0.0"
+            },
+            "dependencies": {
+                "whatwg-url": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+                    "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+                    "dev": true,
+                    "requires": {
+                        "lodash.sortby": "^4.7.0",
+                        "tr46": "^1.0.1",
+                        "webidl-conversions": "^4.0.2"
+                    }
+                }
             }
         },
         "debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
             "requires": {
                 "ms": "2.0.0"
             }
@@ -1579,278 +1447,325 @@
         "decamelize": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
         },
         "decode-uri-component": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "dev": true
         },
         "deep-is": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
         },
         "default-require-extensions": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
             "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+            "dev": true,
             "requires": {
-                "strip-bom": "2.0.0"
+                "strip-bom": "^2.0.0"
             }
         },
         "define-properties": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-            "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
             "requires": {
-                "foreach": "2.0.5",
-                "object-keys": "1.0.11"
+                "object-keys": "^1.0.12"
             }
         },
         "define-property": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+            "dev": true,
             "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 },
                 "kind-of": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
                 }
             }
         },
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
         },
         "detect-indent": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
             "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+            "dev": true,
             "requires": {
-                "repeating": "2.0.1"
+                "repeating": "^2.0.0"
             }
         },
         "detect-newline": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-            "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+            "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+            "dev": true
         },
         "diff": {
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "dev": true
         },
         "domexception": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
             "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+            "dev": true,
             "requires": {
-                "webidl-conversions": "4.0.2"
+                "webidl-conversions": "^4.0.2"
             }
         },
         "ecc-jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-            "optional": true,
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "dev": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.45",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.45.tgz",
-            "integrity": "sha1-RYrBscXHYM6IEaFtK/vZfsMLr7g="
+            "version": "1.3.438",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.438.tgz",
+            "integrity": "sha512-QKMcpfA/fCOnqFHsZvKr2haQQb3eXkDI17zT+4hHxJJThyN5nShcG6q1VR8vRiE/2GCJM+0p3PzinYknkdsBYg==",
+            "dev": true
         },
         "error-ex": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-            "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "es-abstract": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
-            "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
+            "version": "1.17.5",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+            "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+            "dev": true,
             "requires": {
-                "es-to-primitive": "1.1.1",
-                "function-bind": "1.1.1",
-                "has": "1.0.1",
-                "is-callable": "1.1.3",
-                "is-regex": "1.0.4"
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.1.5",
+                "is-regex": "^1.0.5",
+                "object-inspect": "^1.7.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.0",
+                "string.prototype.trimleft": "^2.1.1",
+                "string.prototype.trimright": "^2.1.1"
             }
         },
         "es-to-primitive": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-            "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "dev": true,
             "requires": {
-                "is-callable": "1.1.3",
-                "is-date-object": "1.0.1",
-                "is-symbol": "1.0.1"
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
             }
         },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
         },
         "escodegen": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
-            "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
+            "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+            "dev": true,
             "requires": {
-                "esprima": "3.1.3",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.6.1"
+                "esprima": "^4.0.1",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.6.1"
             },
             "dependencies": {
-                "esprima": {
-                    "version": "3.1.3",
-                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-                },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true,
                     "optional": true
                 }
             }
         },
         "esprima": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-            "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
         },
         "estraverse": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true
         },
         "esutils": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true
         },
         "exec-sh": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
-            "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+            "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+            "dev": true,
             "requires": {
-                "merge": "1.2.0"
+                "merge": "^1.2.0"
             }
         },
         "execa": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
             "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+            "dev": true,
             "requires": {
-                "cross-spawn": "5.1.0",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
             }
         },
         "exit": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true
         },
         "expand-brackets": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "dev": true,
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
             }
         },
         "expand-range": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "dev": true,
             "requires": {
-                "fill-range": "2.2.4"
+                "fill-range": "^2.1.0"
             }
         },
         "expect": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
             "integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
+            "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "jest-diff": "22.4.3",
-                "jest-get-type": "22.4.3",
-                "jest-matcher-utils": "22.4.3",
-                "jest-message-util": "22.4.3",
-                "jest-regex-util": "22.4.3"
+                "ansi-styles": "^3.2.0",
+                "jest-diff": "^22.4.3",
+                "jest-get-type": "^22.4.3",
+                "jest-matcher-utils": "^22.4.3",
+                "jest-message-util": "^22.4.3",
+                "jest-regex-util": "^22.4.3"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                }
             }
         },
         "extend": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true
         },
         "extend-shallow": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+            "dev": true,
             "requires": {
-                "assign-symbols": "1.0.0",
-                "is-extendable": "1.0.1"
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -1859,733 +1774,320 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             }
         },
         "extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
         },
         "fast-deep-equal": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+            "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+            "dev": true
         },
         "fast-json-stable-stringify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
         },
         "fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
         },
         "fb-watchman": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
-            "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
+            "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
+            "dev": true,
             "requires": {
-                "bser": "2.0.0"
+                "bser": "2.1.1"
             }
+        },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "dev": true,
+            "optional": true
         },
         "filename-regex": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+            "dev": true
         },
         "fileset": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
             "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+            "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "minimatch": "3.0.4"
+                "glob": "^7.0.3",
+                "minimatch": "^3.0.3"
             }
         },
         "fill-range": {
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
             "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+            "dev": true,
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "3.0.0",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^3.0.0",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
         },
         "find-up": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+            "dev": true,
             "requires": {
-                "locate-path": "2.0.0"
+                "locate-path": "^2.0.0"
             }
         },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+            "dev": true
         },
         "for-own": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
-        },
-        "foreach": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
         },
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
         },
         "form-data": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "dev": true,
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
             }
         },
         "fragment-cache": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "dev": true,
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
         },
         "fs-readdir-recursive": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-            "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
+            "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+            "dev": true
         },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
         },
         "fsevents": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
-            "integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+            "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+            "dev": true,
             "optional": true,
             "requires": {
-                "nan": "2.10.0",
-                "node-pre-gyp": "0.9.1"
-            },
-            "dependencies": {
-                "abbrev": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "bundled": true
-                },
-                "aproba": {
-                    "version": "1.2.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "are-we-there-yet": {
-                    "version": "1.1.4",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.3.6"
-                    }
-                },
-                "balanced-match": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "brace-expansion": {
-                    "version": "1.1.11",
-                    "bundled": true,
-                    "requires": {
-                        "balanced-match": "1.0.0",
-                        "concat-map": "0.0.1"
-                    }
-                },
-                "chownr": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "code-point-at": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "concat-map": {
-                    "version": "0.0.1",
-                    "bundled": true
-                },
-                "console-control-strings": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "core-util-is": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "debug": {
-                    "version": "2.6.9",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "deep-extend": {
-                    "version": "0.4.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "delegates": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "detect-libc": {
-                    "version": "1.0.3",
-                    "bundled": true,
-                    "optional": true
-                },
-                "fs-minipass": {
-                    "version": "1.2.5",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "minipass": "2.2.4"
-                    }
-                },
-                "fs.realpath": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "gauge": {
-                    "version": "2.7.4",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "aproba": "1.2.0",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
-                    }
-                },
-                "glob": {
-                    "version": "7.1.2",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
-                    }
-                },
-                "has-unicode": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "iconv-lite": {
-                    "version": "0.4.21",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "safer-buffer": "2.1.2"
-                    }
-                },
-                "ignore-walk": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "minimatch": "3.0.4"
-                    }
-                },
-                "inflight": {
-                    "version": "1.0.6",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
-                    }
-                },
-                "inherits": {
-                    "version": "2.0.3",
-                    "bundled": true
-                },
-                "ini": {
-                    "version": "1.3.5",
-                    "bundled": true,
-                    "optional": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "number-is-nan": "1.0.1"
-                    }
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "bundled": true,
-                    "requires": {
-                        "brace-expansion": "1.1.11"
-                    }
-                },
-                "minimist": {
-                    "version": "0.0.8",
-                    "bundled": true
-                },
-                "minipass": {
-                    "version": "2.2.4",
-                    "bundled": true,
-                    "requires": {
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
-                    }
-                },
-                "minizlib": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "minipass": "2.2.4"
-                    }
-                },
-                "mkdirp": {
-                    "version": "0.5.1",
-                    "bundled": true,
-                    "requires": {
-                        "minimist": "0.0.8"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "needle": {
-                    "version": "2.2.0",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "debug": "2.6.9",
-                        "iconv-lite": "0.4.21",
-                        "sax": "1.2.4"
-                    }
-                },
-                "node-pre-gyp": {
-                    "version": "0.9.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "detect-libc": "1.0.3",
-                        "mkdirp": "0.5.1",
-                        "needle": "2.2.0",
-                        "nopt": "4.0.1",
-                        "npm-packlist": "1.1.10",
-                        "npmlog": "4.1.2",
-                        "rc": "1.2.6",
-                        "rimraf": "2.6.2",
-                        "semver": "5.5.0",
-                        "tar": "4.4.1"
-                    }
-                },
-                "nopt": {
-                    "version": "4.0.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "abbrev": "1.1.1",
-                        "osenv": "0.1.5"
-                    }
-                },
-                "npm-bundled": {
-                    "version": "1.0.3",
-                    "bundled": true,
-                    "optional": true
-                },
-                "npm-packlist": {
-                    "version": "1.1.10",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "ignore-walk": "3.0.1",
-                        "npm-bundled": "1.0.3"
-                    }
-                },
-                "npmlog": {
-                    "version": "4.1.2",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
-                    }
-                },
-                "number-is-nan": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "object-assign": {
-                    "version": "4.1.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "once": {
-                    "version": "1.4.0",
-                    "bundled": true,
-                    "requires": {
-                        "wrappy": "1.0.2"
-                    }
-                },
-                "os-homedir": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "os-tmpdir": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "osenv": {
-                    "version": "0.1.5",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
-                    }
-                },
-                "path-is-absolute": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "process-nextick-args": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "rc": {
-                    "version": "1.2.6",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "deep-extend": "0.4.2",
-                        "ini": "1.3.5",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "1.2.0",
-                            "bundled": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "readable-stream": {
-                    "version": "2.3.6",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
-                    }
-                },
-                "rimraf": {
-                    "version": "2.6.2",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "glob": "7.1.2"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.1.1",
-                    "bundled": true
-                },
-                "safer-buffer": {
-                    "version": "2.1.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "sax": {
-                    "version": "1.2.4",
-                    "bundled": true,
-                    "optional": true
-                },
-                "semver": {
-                    "version": "5.5.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "set-blocking": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "signal-exit": {
-                    "version": "3.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "safe-buffer": "5.1.1"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "strip-json-comments": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "tar": {
-                    "version": "4.4.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "chownr": "1.0.1",
-                        "fs-minipass": "1.2.5",
-                        "minipass": "2.2.4",
-                        "minizlib": "1.1.0",
-                        "mkdirp": "0.5.1",
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
-                    }
-                },
-                "util-deprecate": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "wide-align": {
-                    "version": "1.1.2",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "string-width": "1.0.2"
-                    }
-                },
-                "wrappy": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "yallist": {
-                    "version": "3.0.2",
-                    "bundled": true
-                }
+                "bindings": "^1.5.0",
+                "nan": "^2.12.1"
             }
         },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
         },
         "get-caller-file": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-            "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+            "dev": true
         },
         "get-stream": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+            "dev": true
         },
         "get-value": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+            "dev": true
         },
         "getpass": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "glob": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "dev": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             }
         },
         "glob-parent": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+            "dev": true,
             "requires": {
-                "is-glob": "2.0.1"
+                "is-glob": "^2.0.0"
             }
         },
         "globals": {
             "version": "9.18.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-            "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+            "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+            "dev": true
         },
         "graceful-fs": {
-            "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+            "dev": true
         },
         "growly": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-            "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+            "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+            "dev": true
         },
         "handlebars": {
-            "version": "4.0.11",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-            "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+            "version": "4.7.6",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+            "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+            "dev": true,
             "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.8.29"
+                "minimist": "^1.2.5",
+                "neo-async": "^2.6.0",
+                "source-map": "^0.6.1",
+                "uglify-js": "^3.1.4",
+                "wordwrap": "^1.0.0"
             },
             "dependencies": {
-                "async": {
-                    "version": "1.5.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-                },
                 "source-map": {
-                    "version": "0.4.4",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-                    "requires": {
-                        "amdefine": "1.0.1"
-                    }
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
                 }
             }
         },
         "har-schema": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
         },
         "har-validator": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+            "dev": true,
             "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
             }
         },
         "has": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-            "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
             "requires": {
-                "function-bind": "1.1.1"
+                "function-bind": "^1.1.1"
             }
         },
         "has-ansi": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "has-symbols": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+            "dev": true
         },
         "has-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "dev": true,
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 }
             }
         },
@@ -2593,25 +2095,28 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
                             "version": "3.2.2",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -2620,328 +2125,342 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
-        },
-        "hawk": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-            "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-            "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.1",
-                "sntp": "2.1.0"
-            }
-        },
-        "hoek": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-            "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
         },
         "home-or-tmp": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
             "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+            "dev": true,
             "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.1"
             }
         },
         "hosted-git-info": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-            "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+            "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+            "dev": true
         },
         "html-encoding-sniffer": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
             "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+            "dev": true,
             "requires": {
-                "whatwg-encoding": "1.0.3"
+                "whatwg-encoding": "^1.0.1"
             }
         },
         "http-signature": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.1"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "iconv-lite": {
-            "version": "0.4.19",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-            "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
         },
         "import-local": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
             "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+            "dev": true,
             "requires": {
-                "pkg-dir": "2.0.0",
-                "resolve-cwd": "2.0.0"
+                "pkg-dir": "^2.0.0",
+                "resolve-cwd": "^2.0.0"
             }
         },
         "imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
         },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
         },
         "invariant": {
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
             "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "dev": true,
             "requires": {
-                "loose-envify": "1.3.1"
+                "loose-envify": "^1.0.0"
             }
         },
         "invert-kv": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "dev": true
         },
         "is-accessor-descriptor": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+            "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
         },
         "is-binary-path": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+            "dev": true,
             "optional": true,
             "requires": {
-                "binary-extensions": "1.11.0"
+                "binary-extensions": "^1.0.0"
             }
         },
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-        },
-        "is-builtin-module": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-            "requires": {
-                "builtin-modules": "1.1.1"
-            }
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "dev": true
         },
         "is-callable": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-            "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+            "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+            "dev": true
         },
         "is-ci": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-            "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+            "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+            "dev": true,
             "requires": {
-                "ci-info": "1.1.3"
+                "ci-info": "^1.5.0"
             }
         },
         "is-data-descriptor": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+            "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-date-object": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+            "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+            "dev": true
         },
         "is-descriptor": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+            "dev": true,
             "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
             },
             "dependencies": {
                 "kind-of": {
                     "version": "5.1.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
                 }
             }
         },
         "is-dotfile": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+            "dev": true
         },
         "is-equal-shallow": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "dev": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+            "dev": true
         },
         "is-extglob": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+            "dev": true
         },
         "is-finite": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-            "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-            "requires": {
-                "number-is-nan": "1.0.1"
-            }
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+            "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+            "dev": true
         },
         "is-fullwidth-code-point": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
         },
         "is-generator-fn": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-            "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
+            "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
+            "dev": true
         },
         "is-glob": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+            "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             }
         },
         "is-number": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
-            }
-        },
-        "is-odd": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-            "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-            "requires": {
-                "is-number": "4.0.0"
-            },
-            "dependencies": {
-                "is-number": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
-                }
+                "kind-of": "^3.0.2"
             }
         },
         "is-plain-object": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 }
             }
         },
         "is-posix-bracket": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+            "dev": true
         },
         "is-primitive": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+            "dev": true
         },
         "is-regex": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-            "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+            "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+            "dev": true,
             "requires": {
-                "has": "1.0.1"
+                "has": "^1.0.3"
             }
         },
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
         },
         "is-symbol": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-            "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+            "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.1"
+            }
         },
         "is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
         },
         "is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "dev": true
         },
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true
+        },
+        "is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+            "dev": true
         },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
         },
         "isobject": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+            "dev": true,
             "requires": {
                 "isarray": "1.0.0"
             }
@@ -2949,180 +2468,220 @@
         "isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
         },
         "istanbul-api": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
-            "integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.7.tgz",
+            "integrity": "sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==",
+            "dev": true,
             "requires": {
-                "async": "2.6.0",
-                "compare-versions": "3.1.0",
-                "fileset": "2.0.3",
-                "istanbul-lib-coverage": "1.2.0",
-                "istanbul-lib-hook": "1.2.0",
-                "istanbul-lib-instrument": "1.10.1",
-                "istanbul-lib-report": "1.1.4",
-                "istanbul-lib-source-maps": "1.2.4",
-                "istanbul-reports": "1.3.0",
-                "js-yaml": "3.11.0",
-                "mkdirp": "0.5.1",
-                "once": "1.4.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "istanbul-lib-source-maps": {
-                    "version": "1.2.4",
-                    "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz",
-                    "integrity": "sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==",
-                    "requires": {
-                        "debug": "3.1.0",
-                        "istanbul-lib-coverage": "1.2.0",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.2",
-                        "source-map": "0.5.7"
-                    }
-                }
+                "async": "^2.1.4",
+                "fileset": "^2.0.2",
+                "istanbul-lib-coverage": "^1.2.1",
+                "istanbul-lib-hook": "^1.2.2",
+                "istanbul-lib-instrument": "^1.10.2",
+                "istanbul-lib-report": "^1.1.5",
+                "istanbul-lib-source-maps": "^1.2.6",
+                "istanbul-reports": "^1.5.1",
+                "js-yaml": "^3.7.0",
+                "mkdirp": "^0.5.1",
+                "once": "^1.4.0"
             }
         },
         "istanbul-lib-coverage": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
-            "integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A=="
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
+            "integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==",
+            "dev": true
         },
         "istanbul-lib-hook": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.0.tgz",
-            "integrity": "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz",
+            "integrity": "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
+            "dev": true,
             "requires": {
-                "append-transform": "0.4.0"
+                "append-transform": "^0.4.0"
             }
         },
         "istanbul-lib-instrument": {
-            "version": "1.10.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
-            "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
+            "integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
+            "dev": true,
             "requires": {
-                "babel-generator": "6.26.1",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "istanbul-lib-coverage": "1.2.0",
-                "semver": "5.5.0"
+                "babel-generator": "^6.18.0",
+                "babel-template": "^6.16.0",
+                "babel-traverse": "^6.18.0",
+                "babel-types": "^6.18.0",
+                "babylon": "^6.18.0",
+                "istanbul-lib-coverage": "^1.2.1",
+                "semver": "^5.3.0"
             }
         },
         "istanbul-lib-report": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
-            "integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz",
+            "integrity": "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
+            "dev": true,
             "requires": {
-                "istanbul-lib-coverage": "1.2.0",
-                "mkdirp": "0.5.1",
-                "path-parse": "1.0.5",
-                "supports-color": "3.2.3"
+                "istanbul-lib-coverage": "^1.2.1",
+                "mkdirp": "^0.5.1",
+                "path-parse": "^1.0.5",
+                "supports-color": "^3.1.2"
             },
             "dependencies": {
                 "has-flag": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+                    "dev": true
                 },
                 "supports-color": {
                     "version": "3.2.3",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                    "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
         },
         "istanbul-lib-source-maps": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
-            "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz",
+            "integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
+            "dev": true,
             "requires": {
-                "debug": "3.1.0",
-                "istanbul-lib-coverage": "1.2.0",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "source-map": "0.5.7"
+                "debug": "^3.1.0",
+                "istanbul-lib-coverage": "^1.2.1",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.6.1",
+                "source-map": "^0.5.3"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
                     }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
                 }
             }
         },
         "istanbul-reports": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
-            "integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.1.tgz",
+            "integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
+            "dev": true,
             "requires": {
-                "handlebars": "4.0.11"
+                "handlebars": "^4.0.3"
             }
         },
         "jest": {
-            "version": "22.4.3",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-22.4.3.tgz",
-            "integrity": "sha512-FFCdU/pXOEASfHxFDOWUysI/+FFoqiXJADEIXgDKuZyqSmBD3tZ4BEGH7+M79v7czj7bbkhwtd2LaEDcJiM/GQ==",
+            "version": "22.4.4",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-22.4.4.tgz",
+            "integrity": "sha512-eBhhW8OS/UuX3HxgzNBSVEVhSuRDh39Z1kdYkQVWna+scpgsrD7vSeBI7tmEvsguPDMnfJodW28YBnhv/BzSew==",
+            "dev": true,
             "requires": {
-                "import-local": "1.0.0",
-                "jest-cli": "22.4.3"
+                "import-local": "^1.0.0",
+                "jest-cli": "^22.4.4"
             },
             "dependencies": {
-                "jest-cli": {
-                    "version": "22.4.3",
-                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.3.tgz",
-                    "integrity": "sha512-IiHybF0DJNqZPsbjn4Cy4vcqcmImpoFwNFnkehzVw8lTUSl4axZh5DHewu5bdpZF2Y5gUqFKYzH0FH4Qx2k+UA==",
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
                     "requires": {
-                        "ansi-escapes": "3.1.0",
-                        "chalk": "2.4.1",
-                        "exit": "0.1.2",
-                        "glob": "7.1.2",
-                        "graceful-fs": "4.1.11",
-                        "import-local": "1.0.0",
-                        "is-ci": "1.1.0",
-                        "istanbul-api": "1.3.1",
-                        "istanbul-lib-coverage": "1.2.0",
-                        "istanbul-lib-instrument": "1.10.1",
-                        "istanbul-lib-source-maps": "1.2.3",
-                        "jest-changed-files": "22.4.3",
-                        "jest-config": "22.4.3",
-                        "jest-environment-jsdom": "22.4.3",
-                        "jest-get-type": "22.4.3",
-                        "jest-haste-map": "22.4.3",
-                        "jest-message-util": "22.4.3",
-                        "jest-regex-util": "22.4.3",
-                        "jest-resolve-dependencies": "22.4.3",
-                        "jest-runner": "22.4.3",
-                        "jest-runtime": "22.4.3",
-                        "jest-snapshot": "22.4.3",
-                        "jest-util": "22.4.3",
-                        "jest-validate": "22.4.3",
-                        "jest-worker": "22.4.3",
-                        "micromatch": "2.3.11",
-                        "node-notifier": "5.2.1",
-                        "realpath-native": "1.0.0",
-                        "rimraf": "2.6.2",
-                        "slash": "1.0.0",
-                        "string-length": "2.0.0",
-                        "strip-ansi": "4.0.0",
-                        "which": "1.3.0",
-                        "yargs": "10.1.2"
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "jest-cli": {
+                    "version": "22.4.4",
+                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.4.tgz",
+                    "integrity": "sha512-I9dsgkeyjVEEZj9wrGrqlH+8OlNob9Iptyl+6L5+ToOLJmHm4JwOPatin1b2Bzp5R5YRQJ+oiedx7o1H7wJzhA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-escapes": "^3.0.0",
+                        "chalk": "^2.0.1",
+                        "exit": "^0.1.2",
+                        "glob": "^7.1.2",
+                        "graceful-fs": "^4.1.11",
+                        "import-local": "^1.0.0",
+                        "is-ci": "^1.0.10",
+                        "istanbul-api": "^1.1.14",
+                        "istanbul-lib-coverage": "^1.1.1",
+                        "istanbul-lib-instrument": "^1.8.0",
+                        "istanbul-lib-source-maps": "^1.2.1",
+                        "jest-changed-files": "^22.2.0",
+                        "jest-config": "^22.4.4",
+                        "jest-environment-jsdom": "^22.4.1",
+                        "jest-get-type": "^22.1.0",
+                        "jest-haste-map": "^22.4.2",
+                        "jest-message-util": "^22.4.0",
+                        "jest-regex-util": "^22.1.0",
+                        "jest-resolve-dependencies": "^22.1.0",
+                        "jest-runner": "^22.4.4",
+                        "jest-runtime": "^22.4.4",
+                        "jest-snapshot": "^22.4.0",
+                        "jest-util": "^22.4.1",
+                        "jest-validate": "^22.4.4",
+                        "jest-worker": "^22.2.2",
+                        "micromatch": "^2.3.11",
+                        "node-notifier": "^5.2.1",
+                        "realpath-native": "^1.0.0",
+                        "rimraf": "^2.5.4",
+                        "slash": "^1.0.0",
+                        "string-length": "^2.0.0",
+                        "strip-ansi": "^4.0.0",
+                        "which": "^1.2.12",
+                        "yargs": "^10.0.3"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -3131,366 +2690,724 @@
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.4.3.tgz",
             "integrity": "sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
+            "dev": true,
             "requires": {
-                "throat": "4.1.0"
+                "throat": "^4.0.0"
             }
         },
         "jest-config": {
-            "version": "22.4.3",
-            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.3.tgz",
-            "integrity": "sha512-KSg3EOToCgkX+lIvenKY7J8s426h6ahXxaUFJxvGoEk0562Z6inWj1TnKoGycTASwiLD+6kSYFALcjdosq9KIQ==",
+            "version": "22.4.4",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.4.tgz",
+            "integrity": "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
+            "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "glob": "7.1.2",
-                "jest-environment-jsdom": "22.4.3",
-                "jest-environment-node": "22.4.3",
-                "jest-get-type": "22.4.3",
-                "jest-jasmine2": "22.4.3",
-                "jest-regex-util": "22.4.3",
-                "jest-resolve": "22.4.3",
-                "jest-util": "22.4.3",
-                "jest-validate": "22.4.3",
-                "pretty-format": "22.4.3"
+                "chalk": "^2.0.1",
+                "glob": "^7.1.1",
+                "jest-environment-jsdom": "^22.4.1",
+                "jest-environment-node": "^22.4.1",
+                "jest-get-type": "^22.1.0",
+                "jest-jasmine2": "^22.4.4",
+                "jest-regex-util": "^22.1.0",
+                "jest-resolve": "^22.4.2",
+                "jest-util": "^22.4.1",
+                "jest-validate": "^22.4.4",
+                "pretty-format": "^22.4.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "jest-diff": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
             "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
+            "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "diff": "3.5.0",
-                "jest-get-type": "22.4.3",
-                "pretty-format": "22.4.3"
+                "chalk": "^2.0.1",
+                "diff": "^3.2.0",
+                "jest-get-type": "^22.4.3",
+                "pretty-format": "^22.4.3"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "jest-docblock": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
             "integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
+            "dev": true,
             "requires": {
-                "detect-newline": "2.1.0"
+                "detect-newline": "^2.1.0"
             }
         },
         "jest-environment-jsdom": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
             "integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
+            "dev": true,
             "requires": {
-                "jest-mock": "22.4.3",
-                "jest-util": "22.4.3",
-                "jsdom": "11.10.0"
+                "jest-mock": "^22.4.3",
+                "jest-util": "^22.4.3",
+                "jsdom": "^11.5.1"
             }
         },
         "jest-environment-node": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
             "integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
+            "dev": true,
             "requires": {
-                "jest-mock": "22.4.3",
-                "jest-util": "22.4.3"
+                "jest-mock": "^22.4.3",
+                "jest-util": "^22.4.3"
             }
         },
         "jest-get-type": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-            "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
+            "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+            "dev": true
         },
         "jest-haste-map": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz",
             "integrity": "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
+            "dev": true,
             "requires": {
-                "fb-watchman": "2.0.0",
-                "graceful-fs": "4.1.11",
-                "jest-docblock": "22.4.3",
-                "jest-serializer": "22.4.3",
-                "jest-worker": "22.4.3",
-                "micromatch": "2.3.11",
-                "sane": "2.5.2"
+                "fb-watchman": "^2.0.0",
+                "graceful-fs": "^4.1.11",
+                "jest-docblock": "^22.4.3",
+                "jest-serializer": "^22.4.3",
+                "jest-worker": "^22.4.3",
+                "micromatch": "^2.3.11",
+                "sane": "^2.0.0"
             }
         },
         "jest-jasmine2": {
-            "version": "22.4.3",
-            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.3.tgz",
-            "integrity": "sha512-yZCPCJUcEY6R5KJB/VReo1AYI2b+5Ky+C+JA1v34jndJsRcLpU4IZX4rFJn7yDTtdNbO/nNqg+3SDIPNH2ecnw==",
+            "version": "22.4.4",
+            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.4.tgz",
+            "integrity": "sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
+            "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "co": "4.6.0",
-                "expect": "22.4.3",
-                "graceful-fs": "4.1.11",
-                "is-generator-fn": "1.0.0",
-                "jest-diff": "22.4.3",
-                "jest-matcher-utils": "22.4.3",
-                "jest-message-util": "22.4.3",
-                "jest-snapshot": "22.4.3",
-                "jest-util": "22.4.3",
-                "source-map-support": "0.5.5"
+                "chalk": "^2.0.1",
+                "co": "^4.6.0",
+                "expect": "^22.4.0",
+                "graceful-fs": "^4.1.11",
+                "is-generator-fn": "^1.0.0",
+                "jest-diff": "^22.4.0",
+                "jest-matcher-utils": "^22.4.0",
+                "jest-message-util": "^22.4.0",
+                "jest-snapshot": "^22.4.0",
+                "jest-util": "^22.4.1",
+                "source-map-support": "^0.5.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "source-map-support": {
+                    "version": "0.5.19",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+                    "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+                    "dev": true,
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "source-map": "^0.6.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "jest-leak-detector": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
             "integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
+            "dev": true,
             "requires": {
-                "pretty-format": "22.4.3"
+                "pretty-format": "^22.4.3"
             }
         },
         "jest-matcher-utils": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
             "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+            "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "jest-get-type": "22.4.3",
-                "pretty-format": "22.4.3"
+                "chalk": "^2.0.1",
+                "jest-get-type": "^22.4.3",
+                "pretty-format": "^22.4.3"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "jest-message-util": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
             "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
+            "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.46",
-                "chalk": "2.4.1",
-                "micromatch": "2.3.11",
-                "slash": "1.0.0",
-                "stack-utils": "1.0.1"
+                "@babel/code-frame": "^7.0.0-beta.35",
+                "chalk": "^2.0.1",
+                "micromatch": "^2.3.11",
+                "slash": "^1.0.0",
+                "stack-utils": "^1.0.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "jest-mock": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
-            "integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q=="
+            "integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==",
+            "dev": true
         },
         "jest-regex-util": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
-            "integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg=="
+            "integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
+            "dev": true
         },
         "jest-resolve": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
             "integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
+            "dev": true,
             "requires": {
-                "browser-resolve": "1.11.2",
-                "chalk": "2.4.1"
+                "browser-resolve": "^1.11.2",
+                "chalk": "^2.0.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "jest-resolve-dependencies": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
             "integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
+            "dev": true,
             "requires": {
-                "jest-regex-util": "22.4.3"
+                "jest-regex-util": "^22.4.3"
             }
         },
         "jest-runner": {
-            "version": "22.4.3",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.3.tgz",
-            "integrity": "sha512-U7PLlQPRlWNbvOHWOrrVay9sqhBJmiKeAdKIkvX4n1G2tsvzLlf77nBD28GL1N6tGv4RmuTfI8R8JrkvCa+IBg==",
+            "version": "22.4.4",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.4.tgz",
+            "integrity": "sha512-5S/OpB51igQW9xnkM5Tgd/7ZjiAuIoiJAVtvVTBcEBiXBIFzWM3BAMPBM19FX68gRV0KWyFuGKj0EY3M3aceeQ==",
+            "dev": true,
             "requires": {
-                "exit": "0.1.2",
-                "jest-config": "22.4.3",
-                "jest-docblock": "22.4.3",
-                "jest-haste-map": "22.4.3",
-                "jest-jasmine2": "22.4.3",
-                "jest-leak-detector": "22.4.3",
-                "jest-message-util": "22.4.3",
-                "jest-runtime": "22.4.3",
-                "jest-util": "22.4.3",
-                "jest-worker": "22.4.3",
-                "throat": "4.1.0"
+                "exit": "^0.1.2",
+                "jest-config": "^22.4.4",
+                "jest-docblock": "^22.4.0",
+                "jest-haste-map": "^22.4.2",
+                "jest-jasmine2": "^22.4.4",
+                "jest-leak-detector": "^22.4.0",
+                "jest-message-util": "^22.4.0",
+                "jest-runtime": "^22.4.4",
+                "jest-util": "^22.4.1",
+                "jest-worker": "^22.2.2",
+                "throat": "^4.0.0"
             }
         },
         "jest-runtime": {
-            "version": "22.4.3",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.3.tgz",
-            "integrity": "sha512-Eat/esQjevhx9BgJEC8udye+FfoJ2qvxAZfOAWshYGS22HydHn5BgsvPdTtt9cp0fSl5LxYOFA1Pja9Iz2Zt8g==",
+            "version": "22.4.4",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.4.tgz",
+            "integrity": "sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==",
+            "dev": true,
             "requires": {
-                "babel-core": "6.26.3",
-                "babel-jest": "22.4.3",
-                "babel-plugin-istanbul": "4.1.6",
-                "chalk": "2.4.1",
-                "convert-source-map": "1.5.1",
-                "exit": "0.1.2",
-                "graceful-fs": "4.1.11",
-                "jest-config": "22.4.3",
-                "jest-haste-map": "22.4.3",
-                "jest-regex-util": "22.4.3",
-                "jest-resolve": "22.4.3",
-                "jest-util": "22.4.3",
-                "jest-validate": "22.4.3",
-                "json-stable-stringify": "1.0.1",
-                "micromatch": "2.3.11",
-                "realpath-native": "1.0.0",
-                "slash": "1.0.0",
+                "babel-core": "^6.0.0",
+                "babel-jest": "^22.4.4",
+                "babel-plugin-istanbul": "^4.1.5",
+                "chalk": "^2.0.1",
+                "convert-source-map": "^1.4.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.1.11",
+                "jest-config": "^22.4.4",
+                "jest-haste-map": "^22.4.2",
+                "jest-regex-util": "^22.1.0",
+                "jest-resolve": "^22.4.2",
+                "jest-util": "^22.4.1",
+                "jest-validate": "^22.4.4",
+                "json-stable-stringify": "^1.0.1",
+                "micromatch": "^2.3.11",
+                "realpath-native": "^1.0.0",
+                "slash": "^1.0.0",
                 "strip-bom": "3.0.0",
-                "write-file-atomic": "2.3.0",
-                "yargs": "10.1.2"
+                "write-file-atomic": "^2.1.0",
+                "yargs": "^10.0.3"
             },
             "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
                 "strip-bom": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
                 }
             }
         },
         "jest-serializer": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.3.tgz",
-            "integrity": "sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw=="
+            "integrity": "sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw==",
+            "dev": true
         },
         "jest-snapshot": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
             "integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
+            "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "jest-diff": "22.4.3",
-                "jest-matcher-utils": "22.4.3",
-                "mkdirp": "0.5.1",
-                "natural-compare": "1.4.0",
-                "pretty-format": "22.4.3"
+                "chalk": "^2.0.1",
+                "jest-diff": "^22.4.3",
+                "jest-matcher-utils": "^22.4.3",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "pretty-format": "^22.4.3"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "jest-util": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
             "integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
+            "dev": true,
             "requires": {
-                "callsites": "2.0.0",
-                "chalk": "2.4.1",
-                "graceful-fs": "4.1.11",
-                "is-ci": "1.1.0",
-                "jest-message-util": "22.4.3",
-                "mkdirp": "0.5.1",
-                "source-map": "0.6.1"
+                "callsites": "^2.0.0",
+                "chalk": "^2.0.1",
+                "graceful-fs": "^4.1.11",
+                "is-ci": "^1.0.10",
+                "jest-message-util": "^22.4.3",
+                "mkdirp": "^0.5.1",
+                "source-map": "^0.6.0"
             },
             "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
                 }
             }
         },
         "jest-validate": {
-            "version": "22.4.3",
-            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.3.tgz",
-            "integrity": "sha512-CfFM18W3GSP/xgmA4UouIx0ljdtfD2mjeBC6c89Gg17E44D4tQhAcTrZmf9djvipwU30kSTnk6CzcxdCCeSXfA==",
+            "version": "22.4.4",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.4.tgz",
+            "integrity": "sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
+            "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "jest-config": "22.4.3",
-                "jest-get-type": "22.4.3",
-                "leven": "2.1.0",
-                "pretty-format": "22.4.3"
+                "chalk": "^2.0.1",
+                "jest-config": "^22.4.4",
+                "jest-get-type": "^22.1.0",
+                "leven": "^2.1.0",
+                "pretty-format": "^22.4.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "jest-worker": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
             "integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
+            "dev": true,
             "requires": {
-                "merge-stream": "1.0.1"
+                "merge-stream": "^1.0.1"
             }
         },
         "js-tokens": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "dev": true
         },
         "js-yaml": {
-            "version": "3.11.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-            "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+            "dev": true,
             "requires": {
-                "argparse": "1.0.10",
-                "esprima": "4.0.0"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "optional": true
+            "dev": true
         },
         "jsdom": {
-            "version": "11.10.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.10.0.tgz",
-            "integrity": "sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==",
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+            "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+            "dev": true,
             "requires": {
-                "abab": "1.0.4",
-                "acorn": "5.5.3",
-                "acorn-globals": "4.1.0",
-                "array-equal": "1.0.0",
-                "cssom": "0.3.2",
-                "cssstyle": "0.2.37",
-                "data-urls": "1.0.0",
-                "domexception": "1.0.1",
-                "escodegen": "1.9.1",
-                "html-encoding-sniffer": "1.0.2",
-                "left-pad": "1.3.0",
-                "nwmatcher": "1.4.4",
+                "abab": "^2.0.0",
+                "acorn": "^5.5.3",
+                "acorn-globals": "^4.1.0",
+                "array-equal": "^1.0.0",
+                "cssom": ">= 0.3.2 < 0.4.0",
+                "cssstyle": "^1.0.0",
+                "data-urls": "^1.0.0",
+                "domexception": "^1.0.1",
+                "escodegen": "^1.9.1",
+                "html-encoding-sniffer": "^1.0.2",
+                "left-pad": "^1.3.0",
+                "nwsapi": "^2.0.7",
                 "parse5": "4.0.0",
-                "pn": "1.1.0",
-                "request": "2.85.0",
-                "request-promise-native": "1.0.5",
-                "sax": "1.2.4",
-                "symbol-tree": "3.2.2",
-                "tough-cookie": "2.3.4",
-                "w3c-hr-time": "1.0.1",
-                "webidl-conversions": "4.0.2",
-                "whatwg-encoding": "1.0.3",
-                "whatwg-mimetype": "2.1.0",
-                "whatwg-url": "6.4.1",
-                "ws": "4.1.0",
-                "xml-name-validator": "3.0.0"
+                "pn": "^1.1.0",
+                "request": "^2.87.0",
+                "request-promise-native": "^1.0.5",
+                "sax": "^1.2.4",
+                "symbol-tree": "^3.2.2",
+                "tough-cookie": "^2.3.4",
+                "w3c-hr-time": "^1.0.1",
+                "webidl-conversions": "^4.0.2",
+                "whatwg-encoding": "^1.0.3",
+                "whatwg-mimetype": "^2.1.0",
+                "whatwg-url": "^6.4.1",
+                "ws": "^5.2.0",
+                "xml-name-validator": "^3.0.0"
             }
         },
         "jsesc": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-            "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+            "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+            "dev": true
         },
         "json-schema": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
         },
         "json-schema-traverse": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "json-stable-stringify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
         },
         "json5": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+            "dev": true
         },
         "jsonify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
         },
         "jsprim": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
             "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
             "requires": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
@@ -3502,406 +3419,482 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "dev": true,
             "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
             }
-        },
-        "lazy-cache": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-            "optional": true
         },
         "lcid": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "dev": true,
             "requires": {
-                "invert-kv": "1.0.0"
+                "invert-kv": "^1.0.0"
             }
         },
         "left-pad": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-            "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+            "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+            "dev": true
         },
         "leven": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-            "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+            "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+            "dev": true
         },
         "levn": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
             }
         },
         "load-json-file": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+            "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "locate-path": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "dev": true,
             "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
             }
         },
         "lodash": {
-            "version": "4.17.10",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-            "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+            "dev": true
         },
         "lodash.sortby": {
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-            "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
-        },
-        "longest": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+            "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+            "dev": true
         },
         "loose-envify": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-            "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
             "requires": {
-                "js-tokens": "3.0.2"
+                "js-tokens": "^3.0.0 || ^4.0.0"
             }
         },
         "lru-cache": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-            "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+            "dev": true,
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "makeerror": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
             "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+            "dev": true,
             "requires": {
-                "tmpl": "1.0.4"
+                "tmpl": "1.0.x"
             }
         },
         "map-cache": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+            "dev": true
         },
         "map-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "dev": true,
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "math-random": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+            "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+            "dev": true
         },
         "mem": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
             "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+            "dev": true,
             "requires": {
-                "mimic-fn": "1.2.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "merge": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-            "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+            "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+            "dev": true
         },
         "merge-stream": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+            "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.1"
             }
         },
         "micromatch": {
             "version": "2.3.11",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "dev": true,
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
             }
         },
         "mime-db": {
-            "version": "1.33.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-            "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+            "version": "1.44.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+            "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+            "dev": true
         },
         "mime-types": {
-            "version": "2.1.18",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-            "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+            "version": "2.1.27",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+            "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+            "dev": true,
             "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": "1.44.0"
             }
         },
         "mimic-fn": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+            "dev": true
         },
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "dev": true
         },
         "mixin-deep": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-            "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+            "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+            "dev": true,
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
         },
         "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+            "dev": true,
             "requires": {
-                "minimist": "0.0.8"
+                "minimist": "^1.2.5"
             }
         },
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
         },
         "nan": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-            "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+            "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+            "dev": true,
             "optional": true
         },
         "nanomatch": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-            "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+            "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+            "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-odd": "2.0.0",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "arr-diff": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
                 },
                 "array-unique": {
                     "version": "0.3.2",
                     "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
                 },
                 "kind-of": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
                 }
             }
         },
         "natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "neo-async": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+            "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+            "dev": true
         },
         "node-int64": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-            "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+            "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+            "dev": true
         },
         "node-notifier": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-            "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+            "version": "5.4.3",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
+            "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
+            "dev": true,
             "requires": {
-                "growly": "1.3.0",
-                "semver": "5.5.0",
-                "shellwords": "0.1.1",
-                "which": "1.3.0"
+                "growly": "^1.3.0",
+                "is-wsl": "^1.1.0",
+                "semver": "^5.5.0",
+                "shellwords": "^0.1.1",
+                "which": "^1.3.0"
             }
         },
         "normalize-package-data": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-            "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
             "requires": {
-                "hosted-git-info": "2.6.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.5.0",
-                "validate-npm-package-license": "3.0.3"
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            },
+            "dependencies": {
+                "resolve": {
+                    "version": "1.17.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+                    "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
+                }
             }
         },
         "normalize-path": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "npm-run-path": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "dev": true,
             "requires": {
-                "path-key": "2.0.1"
+                "path-key": "^2.0.0"
             }
         },
         "number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
         },
-        "nwmatcher": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-            "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
+        "nwsapi": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+            "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+            "dev": true
         },
         "oauth-sign": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "dev": true
         },
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
         },
         "object-copy": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "dev": true,
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
         },
+        "object-inspect": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+            "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+            "dev": true
+        },
         "object-keys": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-            "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
         },
         "object-visit": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 }
             }
         },
-        "object.getownpropertydescriptors": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-            "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "es-abstract": "1.11.0"
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
+            }
+        },
+        "object.getownpropertydescriptors": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+            "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1"
             }
         },
         "object.omit": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "object.pick": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+            "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 }
             }
         },
@@ -3909,265 +3902,302 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
-            }
-        },
-        "optimist": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-            "requires": {
-                "minimist": "0.0.8",
-                "wordwrap": "0.0.3"
+                "wrappy": "1"
             }
         },
         "optionator": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+            "dev": true,
             "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
-            },
-            "dependencies": {
-                "wordwrap": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-                    "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-                }
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.6",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "word-wrap": "~1.2.3"
             }
         },
         "os-homedir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
         },
         "os-locale": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
             "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+            "dev": true,
             "requires": {
-                "execa": "0.7.0",
-                "lcid": "1.0.0",
-                "mem": "1.1.0"
+                "execa": "^0.7.0",
+                "lcid": "^1.0.0",
+                "mem": "^1.1.0"
             }
         },
         "os-tmpdir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
         },
         "output-file-sync": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
             "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+            "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "mkdirp": "0.5.1",
-                "object-assign": "4.1.1"
+                "graceful-fs": "^4.1.4",
+                "mkdirp": "^0.5.1",
+                "object-assign": "^4.1.0"
             }
         },
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true
         },
         "p-limit": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-            "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+            "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+            "dev": true,
             "requires": {
-                "p-try": "1.0.0"
+                "p-try": "^1.0.0"
             }
         },
         "p-locate": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "dev": true,
             "requires": {
-                "p-limit": "1.2.0"
+                "p-limit": "^1.1.0"
             }
         },
         "p-try": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+            "dev": true
         },
         "parse-glob": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "dev": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             }
         },
         "parse-json": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "dev": true,
             "requires": {
-                "error-ex": "1.3.1"
+                "error-ex": "^1.2.0"
             }
         },
         "parse5": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-            "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+            "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+            "dev": true
         },
         "pascalcase": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+            "dev": true
         },
         "path-exists": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true
         },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
         },
         "path-key": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
         },
         "path-parse": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-            "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "dev": true
         },
         "path-type": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+            "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "performance-now": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
         },
         "pify": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true
         },
         "pinkie": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
         },
         "pinkie-promise": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "pkg-dir": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+            "dev": true,
             "requires": {
-                "find-up": "2.1.0"
+                "find-up": "^2.1.0"
             }
         },
         "pn": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-            "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+            "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+            "dev": true
         },
         "posix-character-classes": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+            "dev": true
         },
         "prelude-ls": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
         },
         "preserve": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+            "dev": true
         },
         "pretty-format": {
             "version": "22.4.3",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
             "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+            "dev": true,
             "requires": {
-                "ansi-regex": "3.0.0",
-                "ansi-styles": "3.2.1"
+                "ansi-regex": "^3.0.0",
+                "ansi-styles": "^3.2.0"
             },
             "dependencies": {
                 "ansi-regex": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
                 }
             }
         },
         "private": {
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+            "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+            "dev": true
         },
         "process-nextick-args": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
         },
         "pseudomap": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "dev": true
+        },
+        "psl": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+            "dev": true
         },
         "punycode": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-            "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "dev": true
         },
         "qs": {
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+            "dev": true
         },
         "randomatic": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-            "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+            "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+            "dev": true,
             "requires": {
-                "is-number": "4.0.0",
-                "kind-of": "6.0.2",
-                "math-random": "1.0.1"
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
             },
             "dependencies": {
                 "is-number": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
                 },
                 "kind-of": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
                 }
             }
         },
@@ -4175,333 +4205,112 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+            "dev": true,
             "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
             }
         },
         "read-pkg-up": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+            "dev": true,
             "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
             },
             "dependencies": {
                 "find-up": {
                     "version": "1.1.2",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                    "dev": true,
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-exists": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                    "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 }
             }
         },
         "readable-stream": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
         "readdirp": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-            "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+            "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+            "dev": true,
             "optional": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.3.6",
-                "set-immediate-shim": "1.0.1"
-            }
-        },
-        "realpath-native": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
-            "integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
-            "requires": {
-                "util.promisify": "1.0.0"
-            }
-        },
-        "regenerate": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-            "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
-        },
-        "regenerator-runtime": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-        },
-        "regenerator-transform": {
-            "version": "0.9.11",
-            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
-            "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "private": "0.1.8"
-            }
-        },
-        "regex-cache": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-            "requires": {
-                "is-equal-shallow": "0.1.3"
-            }
-        },
-        "regex-not": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-            "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-            "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
-            }
-        },
-        "regexpu-core": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-            "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-            "requires": {
-                "regenerate": "1.3.3",
-                "regjsgen": "0.2.0",
-                "regjsparser": "0.1.5"
-            }
-        },
-        "regjsgen": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-            "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
-        },
-        "regjsparser": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-            "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-            "requires": {
-                "jsesc": "0.5.0"
-            },
-            "dependencies": {
-                "jsesc": {
-                    "version": "0.5.0",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-                }
-            }
-        },
-        "remove-trailing-separator": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
-        },
-        "repeat-element": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
-        },
-        "repeat-string": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-        },
-        "repeating": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-            "requires": {
-                "is-finite": "1.0.2"
-            }
-        },
-        "request": {
-            "version": "2.85.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-            "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
-            "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.7.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.18",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.2",
-                "safe-buffer": "5.1.2",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
-            }
-        },
-        "request-promise-core": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-            "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-            "requires": {
-                "lodash": "4.17.10"
-            }
-        },
-        "request-promise-native": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-            "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
-            "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.4"
-            }
-        },
-        "require-directory": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-        },
-        "require-main-filename": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-        },
-        "resolve": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-            "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
-        },
-        "resolve-cwd": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-            "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-            "requires": {
-                "resolve-from": "3.0.0"
-            }
-        },
-        "resolve-from": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-            "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-        },
-        "resolve-url": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-        },
-        "ret": {
-            "version": "0.1.15",
-            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
-        },
-        "right-align": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-            "optional": true,
-            "requires": {
-                "align-text": "0.1.4"
-            }
-        },
-        "rimraf": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-            "requires": {
-                "glob": "7.1.2"
-            }
-        },
-        "rsvp": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-            "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
-        },
-        "safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "safe-regex": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-            "requires": {
-                "ret": "0.1.15"
-            }
-        },
-        "sane": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
-            "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
-            "requires": {
-                "anymatch": "2.0.0",
-                "capture-exit": "1.2.0",
-                "exec-sh": "0.2.1",
-                "fb-watchman": "2.0.0",
-                "fsevents": "1.2.3",
-                "micromatch": "3.1.10",
-                "minimist": "1.2.0",
-                "walker": "1.0.7",
-                "watch": "0.18.0"
+                "graceful-fs": "^4.1.11",
+                "micromatch": "^3.1.10",
+                "readable-stream": "^2.0.2"
             },
             "dependencies": {
                 "arr-diff": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true,
+                    "optional": true
                 },
                 "array-unique": {
                     "version": "0.3.2",
                     "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true,
+                    "optional": true
                 },
                 "braces": {
                     "version": "2.3.2",
                     "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
+                    "optional": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "optional": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -4510,46 +4319,56 @@
                     "version": "2.1.4",
                     "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
+                    "optional": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
                             "version": "0.2.5",
                             "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
+                            "optional": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "optional": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
                             "version": "0.1.6",
                             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "dev": true,
+                            "optional": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
                                     "version": "3.2.2",
                                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "optional": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -4558,16 +4377,20 @@
                             "version": "0.1.4",
                             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "dev": true,
+                            "optional": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
                                     "version": "3.2.2",
                                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "optional": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -4576,16 +4399,20 @@
                             "version": "0.1.6",
                             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "dev": true,
+                            "optional": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
                             "version": "5.1.0",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true,
+                            "optional": true
                         }
                     }
                 },
@@ -4593,31 +4420,37 @@
                     "version": "2.0.4",
                     "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "dev": true,
+                    "optional": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
                             "version": "1.0.0",
                             "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
+                            "optional": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "optional": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -4626,19 +4459,23 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "optional": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "optional": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -4647,42 +4484,52 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "optional": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "optional": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "optional": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-number": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "optional": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
                             "version": "3.2.2",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "optional": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -4690,78 +4537,622 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true,
+                    "optional": true
                 },
                 "kind-of": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true,
+                    "optional": true
                 },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "optional": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.9",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                }
+            }
+        },
+        "realpath-native": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+            "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+            "dev": true,
+            "requires": {
+                "util.promisify": "^1.0.0"
+            }
+        },
+        "regenerate": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+            "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+            "dev": true
+        },
+        "regenerator-runtime": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+            "dev": true
+        },
+        "regenerator-transform": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+            "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.18.0",
+                "babel-types": "^6.19.0",
+                "private": "^0.1.6"
+            }
+        },
+        "regex-cache": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+            "dev": true,
+            "requires": {
+                "is-equal-shallow": "^0.1.3"
+            }
+        },
+        "regex-not": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+            "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
+            }
+        },
+        "regexpu-core": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+            "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+            "dev": true,
+            "requires": {
+                "regenerate": "^1.2.1",
+                "regjsgen": "^0.2.0",
+                "regjsparser": "^0.1.4"
+            }
+        },
+        "regjsgen": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+            "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+            "dev": true
+        },
+        "regjsparser": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+            "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+            "dev": true,
+            "requires": {
+                "jsesc": "~0.5.0"
+            },
+            "dependencies": {
+                "jsesc": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                    "dev": true
+                }
+            }
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+            "dev": true
+        },
+        "repeat-element": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+            "dev": true
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
+        },
+        "repeating": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+            "dev": true,
+            "requires": {
+                "is-finite": "^1.0.0"
+            }
+        },
+        "request": {
+            "version": "2.88.2",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.5.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            }
+        },
+        "request-promise-core": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+            "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.15"
+            }
+        },
+        "request-promise-native": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
+            "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+            "dev": true,
+            "requires": {
+                "request-promise-core": "1.1.3",
+                "stealthy-require": "^1.1.1",
+                "tough-cookie": "^2.3.3"
+            }
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+            "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+            "dev": true
+        },
+        "resolve-cwd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+            "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+            "dev": true,
+            "requires": {
+                "resolve-from": "^3.0.0"
+            }
+        },
+        "resolve-from": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+            "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+            "dev": true
+        },
+        "resolve-url": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+            "dev": true
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "dev": true
+        },
+        "rimraf": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
+        "rsvp": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+            "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+            "dev": true
+        },
+        "safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
+        "safe-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "dev": true,
+            "requires": {
+                "ret": "~0.1.10"
+            }
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
+        },
+        "sane": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
+            "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
+            "dev": true,
+            "requires": {
+                "anymatch": "^2.0.0",
+                "capture-exit": "^1.2.0",
+                "exec-sh": "^0.2.0",
+                "fb-watchman": "^2.0.0",
+                "fsevents": "^1.2.3",
+                "micromatch": "^3.1.4",
+                "minimist": "^1.1.1",
+                "walker": "~1.0.5",
+                "watch": "~0.18.0"
+            },
+            "dependencies": {
+                "anymatch": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+                    "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+                    "dev": true,
+                    "requires": {
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
                     }
                 },
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "expand-brackets": {
+                    "version": "2.1.4",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
+                    "requires": {
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "0.1.4",
+                            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "dev": true,
+                            "requires": {
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
+                            }
+                        },
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
+                        }
+                    }
+                },
+                "extglob": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+                    "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "dev": true,
+                    "requires": {
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^1.0.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
                 }
             }
         },
         "sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
         },
         "semver": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-            "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true
         },
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-        },
-        "set-immediate-shim": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-            "optional": true
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
         },
         "set-value": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-            "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+            "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+            "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -4770,59 +5161,67 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
         },
         "shellwords": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-            "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+            "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+            "dev": true
         },
         "signal-exit": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+            "dev": true
         },
         "slash": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+            "dev": true
         },
         "snapdragon": {
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+            "dev": true,
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.1",
-                "use": "3.1.0"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
             },
             "dependencies": {
                 "define-property": {
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -4831,55 +5230,62 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "dev": true,
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 },
                 "kind-of": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
                 }
             }
         },
@@ -4887,132 +5293,132 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
-            }
-        },
-        "sntp": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-            "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-            "requires": {
-                "hoek": "4.2.1"
+                "kind-of": "^3.2.0"
             }
         },
         "source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+            "dev": true
         },
         "source-map-resolve": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-            "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+            "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+            "dev": true,
             "requires": {
-                "atob": "2.1.1",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.1.2",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-support": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
-            "integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
+            "version": "0.4.18",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+            "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+            "dev": true,
             "requires": {
-                "buffer-from": "1.0.0",
-                "source-map": "0.6.1"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-                }
+                "source-map": "^0.5.6"
             }
         },
         "source-map-url": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+            "dev": true
         },
         "spdx-correct": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-            "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+            "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+            "dev": true,
             "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-            "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+            "dev": true
         },
         "spdx-expression-parse": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "dev": true,
             "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-            "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+            "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+            "dev": true
         },
         "split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             }
         },
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
         },
         "sshpk": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-            "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+            "dev": true,
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
             }
         },
         "stack-utils": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-            "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+            "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+            "dev": true
         },
         "static-extend": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -5020,531 +5426,320 @@
         "stealthy-require": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+            "dev": true
         },
         "string-length": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
             "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+            "dev": true,
             "requires": {
-                "astral-regex": "1.0.0",
-                "strip-ansi": "4.0.0"
+                "astral-regex": "^1.0.0",
+                "strip-ansi": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
             }
         },
         "string-width": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "string.prototype.trimend": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+            "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5"
+            }
+        },
+        "string.prototype.trimleft": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+            "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5",
+                "string.prototype.trimstart": "^1.0.0"
+            }
+        },
+        "string.prototype.trimright": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+            "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5",
+                "string.prototype.trimend": "^1.0.0"
+            }
+        },
+        "string.prototype.trimstart": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+            "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5"
             }
         },
         "string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
             }
         },
-        "stringstream": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-        },
         "strip-ansi": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
             "requires": {
-                "ansi-regex": "3.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-                }
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+            "dev": true,
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-eof": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true
         },
         "supports-color": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-            "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-            "requires": {
-                "has-flag": "3.0.0"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "dev": true
         },
         "symbol-tree": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-            "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true
         },
         "test-exclude": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
-            "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.3.tgz",
+            "integrity": "sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==",
+            "dev": true,
             "requires": {
-                "arrify": "1.0.1",
-                "micromatch": "3.1.10",
-                "object-assign": "4.1.1",
-                "read-pkg-up": "1.0.1",
-                "require-main-filename": "1.0.1"
-            },
-            "dependencies": {
-                "arr-diff": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-                },
-                "array-unique": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-                },
-                "braces": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-                    "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "0.1.1"
-                            }
-                        }
-                    }
-                },
-                "expand-brackets": {
-                    "version": "2.1.4",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-                    "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "0.2.5",
-                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                            "requires": {
-                                "is-descriptor": "0.1.6"
-                            }
-                        },
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "0.1.1"
-                            }
-                        },
-                        "is-accessor-descriptor": {
-                            "version": "0.1.6",
-                            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-                            "requires": {
-                                "kind-of": "3.2.2"
-                            },
-                            "dependencies": {
-                                "kind-of": {
-                                    "version": "3.2.2",
-                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                                    "requires": {
-                                        "is-buffer": "1.1.6"
-                                    }
-                                }
-                            }
-                        },
-                        "is-data-descriptor": {
-                            "version": "0.1.4",
-                            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                            "requires": {
-                                "kind-of": "3.2.2"
-                            },
-                            "dependencies": {
-                                "kind-of": {
-                                    "version": "3.2.2",
-                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                                    "requires": {
-                                        "is-buffer": "1.1.6"
-                                    }
-                                }
-                            }
-                        },
-                        "is-descriptor": {
-                            "version": "0.1.6",
-                            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                            "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
-                            }
-                        },
-                        "kind-of": {
-                            "version": "5.1.0",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-                        }
-                    }
-                },
-                "extglob": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-                    "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-                    "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                            "requires": {
-                                "is-descriptor": "1.0.2"
-                            }
-                        },
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "0.1.1"
-                            }
-                        }
-                    }
-                },
-                "fill-range": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-                    "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "0.1.1"
-                            }
-                        }
-                    }
-                },
-                "is-accessor-descriptor": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "requires": {
-                        "kind-of": "6.0.2"
-                    }
-                },
-                "is-data-descriptor": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "requires": {
-                        "kind-of": "6.0.2"
-                    }
-                },
-                "is-descriptor": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
-                    }
-                },
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "requires": {
-                        "kind-of": "3.2.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "requires": {
-                                "is-buffer": "1.1.6"
-                            }
-                        }
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-                },
-                "kind-of": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-                },
-                "micromatch": {
-                    "version": "3.1.10",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-                    "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.9",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
-                    }
-                }
+                "arrify": "^1.0.1",
+                "micromatch": "^2.3.11",
+                "object-assign": "^4.1.0",
+                "read-pkg-up": "^1.0.1",
+                "require-main-filename": "^1.0.1"
             }
         },
         "throat": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-            "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
+            "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+            "dev": true
         },
         "tmpl": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+            "dev": true
         },
         "to-fast-properties": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-            "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+            "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+            "dev": true
         },
         "to-object-path": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "to-regex": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+            "dev": true,
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "to-regex-range": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+            "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             },
             "dependencies": {
                 "is-number": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 }
             }
         },
         "tough-cookie": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-            "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+            "dev": true,
             "requires": {
-                "punycode": "1.4.1"
-            },
-            "dependencies": {
-                "punycode": {
-                    "version": "1.4.1",
-                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-                }
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
             }
         },
         "tr46": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
             "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+            "dev": true,
             "requires": {
-                "punycode": "2.1.0"
+                "punycode": "^2.1.0"
             }
         },
         "trim-right": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+            "dev": true
         },
         "tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-            "optional": true
+            "dev": true
         },
         "type-check": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2"
+                "prelude-ls": "~1.1.2"
             }
         },
         "uglify-js": {
-            "version": "2.8.29",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-            "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+            "version": "3.9.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.3.tgz",
+            "integrity": "sha512-r5ImcL6QyzQGVimQoov3aL2ZScywrOgBXGndbWrdehKoSvGe/RmiE5Jpw/v+GvxODt6l2tpBXwA7n+qZVlHBMA==",
+            "dev": true,
             "optional": true,
             "requires": {
-                "source-map": "0.5.7",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
-            },
-            "dependencies": {
-                "yargs": {
-                    "version": "3.10.0",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                    "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-                    "optional": true,
-                    "requires": {
-                        "camelcase": "1.2.1",
-                        "cliui": "2.1.0",
-                        "decamelize": "1.2.0",
-                        "window-size": "0.1.0"
-                    }
-                }
+                "commander": "~2.20.3"
             }
         },
-        "uglify-to-browserify": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-            "optional": true
-        },
         "union-value": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-            "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+            "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+            "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "0.4.3"
-            },
-            "dependencies": {
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "requires": {
-                        "is-extendable": "0.1.1"
-                    }
-                },
-                "set-value": {
-                    "version": "0.4.3",
-                    "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-                    "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "to-object-path": "0.3.0"
-                    }
-                }
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^2.0.1"
             }
         },
         "unset-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "dev": true,
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
                     "version": "0.3.1",
                     "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "dev": true,
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
                             "version": "2.1.0",
                             "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "dev": true,
                             "requires": {
                                 "isarray": "1.0.0"
                             }
@@ -5554,203 +5749,213 @@
                 "has-values": {
                     "version": "0.1.4",
                     "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+                    "dev": true
                 },
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 }
+            }
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
             }
         },
         "urix": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+            "dev": true
         },
         "use": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-            "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-            "requires": {
-                "kind-of": "6.0.2"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-                }
-            }
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+            "dev": true
         },
         "user-home": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-            "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+            "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+            "dev": true
         },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
         },
         "util.promisify": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-            "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
+            "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
+            "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "object.getownpropertydescriptors": "2.0.3"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.2",
+                "has-symbols": "^1.0.1",
+                "object.getownpropertydescriptors": "^2.1.0"
             }
         },
         "uuid": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-            "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+            "dev": true
         },
         "v8flags": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
             "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+            "dev": true,
             "requires": {
-                "user-home": "1.1.1"
+                "user-home": "^1.1.1"
             }
         },
         "validate-npm-package-license": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-            "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
             "requires": {
-                "spdx-correct": "3.0.0",
-                "spdx-expression-parse": "3.0.0"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
             }
         },
         "verror": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             }
         },
         "w3c-hr-time": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
-            "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+            "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+            "dev": true,
             "requires": {
-                "browser-process-hrtime": "0.1.2"
+                "browser-process-hrtime": "^1.0.0"
             }
         },
         "walker": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
             "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+            "dev": true,
             "requires": {
-                "makeerror": "1.0.11"
+                "makeerror": "1.0.x"
             }
         },
         "watch": {
             "version": "0.18.0",
             "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
             "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+            "dev": true,
             "requires": {
-                "exec-sh": "0.2.1",
-                "minimist": "1.2.0"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-                }
+                "exec-sh": "^0.2.0",
+                "minimist": "^1.2.0"
             }
         },
         "webidl-conversions": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-            "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+            "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+            "dev": true
         },
         "whatwg-encoding": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-            "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+            "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+            "dev": true,
             "requires": {
-                "iconv-lite": "0.4.19"
+                "iconv-lite": "0.4.24"
             }
         },
         "whatwg-mimetype": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
-            "integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew=="
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+            "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+            "dev": true
         },
         "whatwg-url": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
-            "integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+            "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+            "dev": true,
             "requires": {
-                "lodash.sortby": "4.7.0",
-                "tr46": "1.0.1",
-                "webidl-conversions": "4.0.2"
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^1.0.1",
+                "webidl-conversions": "^4.0.2"
             }
         },
         "which": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-            "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
         },
-        "window-size": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-            "optional": true
+        "word-wrap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+            "dev": true
         },
         "wordwrap": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+            "dev": true
         },
         "wrap-ansi": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dev": true,
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
             },
             "dependencies": {
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "string-width": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "requires": {
-                        "ansi-regex": "2.1.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 }
             }
@@ -5758,86 +5963,74 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "write-file-atomic": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-            "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+            "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+            "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "imurmurhash": "0.1.4",
-                "signal-exit": "3.0.2"
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
             }
         },
         "ws": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-            "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+            "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+            "dev": true,
             "requires": {
-                "async-limiter": "1.0.0",
-                "safe-buffer": "5.1.2"
+                "async-limiter": "~1.0.0"
             }
         },
         "xml-name-validator": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-            "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+            "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+            "dev": true
         },
         "y18n": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+            "dev": true
         },
         "yallist": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+            "dev": true
         },
         "yargs": {
             "version": "10.1.2",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
             "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+            "dev": true,
             "requires": {
-                "cliui": "4.1.0",
-                "decamelize": "1.2.0",
-                "find-up": "2.1.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "2.1.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "8.1.0"
-            },
-            "dependencies": {
-                "cliui": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-                    "requires": {
-                        "string-width": "2.1.1",
-                        "strip-ansi": "4.0.0",
-                        "wrap-ansi": "2.1.0"
-                    }
-                }
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^8.1.0"
             }
         },
         "yargs-parser": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
             "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+            "dev": true,
             "requires": {
-                "camelcase": "4.1.0"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-                }
+                "camelcase": "^4.1.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "texturepacker-command-line",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "Node wrapper around TexturePacker command line tool",
     "main": "./dist/index.js",
     "repository": {
@@ -19,7 +19,7 @@
         "singleQuote": true,
         "semi": true
     },
-    "dependencies": {
+    "devDependencies": {
         "babel-cli": "^6.26.0",
         "babel-preset-env": "^1.6.1",
         "jest": "^22.4.3"


### PR DESCRIPTION
Hi strewhella

As per #1 I have switched the dependencies to devDependencies to stop the Babel 6 install (we are using Babel 7).


Signed-off-by: Stephen Hamilton <stephenhamilton@mac.com>